### PR TITLE
Fix pytest which couldn't be run due to unknown option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,5 @@ add-ignore = D1
 test = pytest
 
 [tool:pytest]
-collect_ignore = ['setup.py']
+testpaths =
+    tests


### PR DESCRIPTION
Explicitly set tespaths to tests folder.