### PR TITLE
Add black formatter configuration to project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 dist: xenial
 language: python
 python:
+  - 3.9
+  - 3.8
   - 3.7
   - 3.6
-  - 3.5
 
 install: pip install -U tox-travis
 

--- a/depx/cli.py
+++ b/depx/cli.py
@@ -1,7 +1,5 @@
 import click
-from depx.graph import (
-    create_graph_from, to_json, to_html, to_graphml, to_dotfile
-)
+from depx.graph import create_graph_from, to_json, to_html, to_graphml, to_dotfile
 from depx.parsing import find_imports, filter_top_level_names
 import sys
 
@@ -10,22 +8,24 @@ formatters = {
     'json': to_json,
     'html': to_html,
     'graphml': to_graphml,
-    'dot': to_dotfile
+    'dot': to_dotfile,
 }
 
 
 @click.command()
 @click.argument('path')
 @click.option(
-    '--format', '-f',
+    '--format',
+    '-f',
     type=click.Choice(formatters),
     default='json',
-    help='Graph output format.'
+    help='Graph output format.',
 )
 @click.option(
-    '--short-names/--no-short-names', '-s/ ',
+    '--short-names/--no-short-names',
+    '-s/ ',
     default=False,
-    help='Use the top-level name only for all dependencies (up to first).'
+    help='Use the top-level name only for all dependencies (up to first).',
 )
 def main(path, **kwargs):
     to_format = kwargs['format']

--- a/depx/parsing.py
+++ b/depx/parsing.py
@@ -7,7 +7,9 @@ import re
 logger = logging.getLogger(__name__)
 
 
-def _dependency(*, from_module, to_module, category='', is_relative=False, level=0, **kwargs):
+def _dependency(
+    *, from_module, to_module, category='', is_relative=False, level=0, **kwargs
+):
     dep = {
         'from_module': from_module,
         'to_module': to_module,  # currently, this could also be a symbol within a module
@@ -30,6 +32,7 @@ def _goes_local(node):
 
 def _walk(node):
     from collections import deque
+
     iter_child_nodes = ast.iter_child_nodes
     todo = deque([(node, False)])
     while todo:
@@ -78,9 +81,7 @@ def find_imports(path):
 
 def find_imports_in_directory(directory_path):
     for path, subdirs, files in os.walk(directory_path):
-        subdirs[:] = [
-            d for d in subdirs if _is_package(os.path.join(path, d))
-        ]
+        subdirs[:] = [d for d in subdirs if _is_package(os.path.join(path, d))]
         for filename in files:
             module_path = os.path.join(path, filename)
             if not _is_module(module_path):
@@ -117,7 +118,9 @@ def find_imports_from_text(text, base_name):
             module = node.module
             for alias in node.names:
                 if level:
-                    to_module = module or alias.name  # module is None for 'from . import'
+                    to_module = (
+                        module or alias.name
+                    )  # module is None for 'from . import'
                     to_module = _resolve_relative_name(to_module, base_name, level)
                 else:
                     to_module = module
@@ -146,7 +149,8 @@ def _resolve_relative_name(name, base_name, level):
     if not (parts and all(parts)) or len(parts) < level:
         logger.warning(
             'Unable to resolve relative name %r: bad or missing basename (%r)',
-            name, base_name
+            name,
+            base_name,
         )
         return name
     resolved_base = parts[:-level]
@@ -155,5 +159,6 @@ def _resolve_relative_name(name, base_name, level):
 
 if __name__ == '__main__':
     from pprint import pprint
+
     for x in find_module_imports(__file__):
         pprint(x)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('..'))
 
 import depx
@@ -110,15 +111,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -128,9 +126,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'depx.tex',
-     u'Depx Documentation',
-     u'Til Boerner', 'manual'),
+    (master_doc, 'depx.tex', u'Depx Documentation', u'Til Boerner', 'manual'),
 ]
 
 
@@ -138,11 +134,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'depx',
-     u'Depx Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, 'depx', u'Depx Documentation', [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -151,13 +143,13 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'depx',
-     u'Depx Documentation',
-     author,
-     'depx',
-     'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        'depx',
+        u'Depx Documentation',
+        author,
+        'depx',
+        'One line description of project.',
+        'Miscellaneous',
+    ),
 ]
-
-
-

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,13 +7,20 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-marker = "sys_platform == \"win32\""
 
 [[package]]
 name = "attrs"
@@ -24,10 +31,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
 name = "babel"
@@ -41,8 +48,31 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 pytz = ">=2015.7"
 
 [[package]]
+name = "black"
+version = "20.8b1"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+appdirs = "*"
+click = ">=7.1.2"
+dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.6,<1"
+regex = ">=2020.1.8"
+toml = ">=0.10.1"
+typed-ast = ">=1.4.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
 name = "certifi"
-version = "2020.6.20"
+version = "2020.11.8"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
 optional = false
@@ -58,11 +88,11 @@ python-versions = "*"
 
 [[package]]
 name = "click"
-version = "7.0"
+version = "7.1.2"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "colorama"
@@ -71,7 +101,6 @@ description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-marker = "sys_platform == \"win32\""
 
 [[package]]
 name = "coverage"
@@ -83,6 +112,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
 toml = ["toml"]
+
+[[package]]
+name = "dataclasses"
+version = "0.7"
+description = "A backport of the dataclasses module for Python 3.6"
+category = "dev"
+optional = false
+python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "decorator"
@@ -109,13 +146,10 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
-
-[package.dependencies.importlib-metadata]
-version = "*"
-python = "<3.8"
 
 [[package]]
 name = "idna"
@@ -140,14 +174,13 @@ description = "Read metadata from Python packages"
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-marker = "python_version < \"3.8\""
+
+[package.dependencies]
+zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
-
-[package.dependencies]
-zipp = ">=0.5"
 
 [[package]]
 name = "iniconfig"
@@ -165,11 +198,11 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
-[package.extras]
-i18n = ["Babel (>=0.8)"]
-
 [package.dependencies]
 MarkupSafe = ">=0.23"
+
+[package.extras]
+i18n = ["Babel (>=0.8)"]
 
 [[package]]
 name = "markupsafe"
@@ -188,15 +221,26 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "networkx"
-version = "2.4"
+version = "2.5"
 description = "Python package for creating and manipulating graphs and networks"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
+
+[package.dependencies]
+decorator = ">=4.3.0"
 
 [package.extras]
-all = ["numpy", "scipy", "pandas", "matplotlib", "pygraphviz", "pydot", "pyyaml", "gdal", "lxml", "pytest"]
+all = ["numpy", "scipy", "pandas", "matplotlib", "pygraphviz", "pydot", "pyyaml", "lxml", "pytest"]
 gdal = ["gdal"]
 lxml = ["lxml"]
 matplotlib = ["matplotlib"]
@@ -207,9 +251,6 @@ pygraphviz = ["pygraphviz"]
 pytest = ["pytest"]
 pyyaml = ["pyyaml"]
 scipy = ["scipy"]
-
-[package.dependencies]
-decorator = ">=4.3.0"
 
 [[package]]
 name = "packaging"
@@ -224,16 +265,12 @@ pyparsing = ">=2.0.2"
 six = "*"
 
 [[package]]
-name = "pathlib2"
-version = "2.3.5"
-description = "Object-oriented filesystem paths"
+name = "pathspec"
+version = "0.8.1"
+description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = "*"
-marker = "python_version < \"3.6\""
-
-[package.dependencies]
-six = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pluggy"
@@ -243,13 +280,11 @@ category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
 [package.extras]
 dev = ["pre-commit", "tox"]
-
-[package.dependencies]
-[package.dependencies.importlib-metadata]
-version = ">=0.12"
-python = "<3.8"
 
 [[package]]
 name = "py"
@@ -310,32 +345,33 @@ category = "dev"
 optional = false
 python-versions = ">=3.5"
 
-[package.extras]
-checkqa_mypy = ["mypy (0.780)"]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
-
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.8.2"
 toml = "*"
 
-[package.dependencies.importlib-metadata]
-version = ">=0.12"
-python = "<3.8"
-
-[package.dependencies.pathlib2]
-version = ">=2.2.0"
-python = "<3.6"
+[package.extras]
+checkqa_mypy = ["mypy (==0.780)"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
 name = "pytz"
 version = "2020.4"
 description = "World timezone definitions, modern and historical"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "regex"
+version = "2020.10.28"
+description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
 python-versions = "*"
@@ -348,15 +384,15 @@ category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
-[package.extras]
-security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
-
 [package.dependencies]
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<4"
 idna = ">=2.5,<3"
 urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
 name = "six"
@@ -382,22 +418,16 @@ category = "dev"
 optional = false
 python-versions = ">=3.5"
 
-[package.extras]
-docs = ["sphinxcontrib-websupport"]
-lint = ["flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.790)", "docutils-stubs"]
-test = ["pytest", "pytest-cov", "html5lib", "typed-ast", "cython"]
-
 [package.dependencies]
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
-colorama = ">=0.3.5"
+colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.12"
 imagesize = "*"
 Jinja2 = ">=2.3"
 packaging = "*"
 Pygments = ">=2.0"
 requests = ">=2.5.0"
-setuptools = "*"
 snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
@@ -405,6 +435,11 @@ sphinxcontrib-htmlhelp = "*"
 sphinxcontrib-jsmath = "*"
 sphinxcontrib-qthelp = "*"
 sphinxcontrib-serializinghtml = "*"
+
+[package.extras]
+docs = ["sphinxcontrib-websupport"]
+lint = ["flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.790)", "docutils-stubs"]
+test = ["pytest", "pytest-cov", "html5lib", "typed-ast", "cython"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
@@ -486,6 +521,22 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "typed-ast"
+version = "1.4.1"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "urllib3"
 version = "1.25.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -496,30 +547,33 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "zipp"
-version = "1.2.0"
+version = "3.4.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
-python-versions = ">=2.7"
-marker = "python_version < \"3.8\""
+python-versions = ">=3.6"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-lock-version = "1.0"
-python-versions = "^3.5"
-content-hash = "7b4c65e85d00ea718a2d120246433a4ed6f0bf08a8790fab7a74b30008d06447"
+lock-version = "1.1"
+python-versions = "^3.6"
+content-hash = "60ef7abbefbd7da702a5539700e590fe7c54dbde59da7d81c0af8df5e7b1de83"
 
 [metadata.files]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -533,17 +587,20 @@ babel = [
     {file = "Babel-2.8.0-py2.py3-none-any.whl", hash = "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"},
     {file = "Babel-2.8.0.tar.gz", hash = "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38"},
 ]
+black = [
+    {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
+]
 certifi = [
-    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
-    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
+    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 click = [
-    {file = "Click-7.0-py2.py3-none-any.whl", hash = "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13"},
-    {file = "Click-7.0.tar.gz", hash = "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"},
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -584,6 +641,10 @@ coverage = [
     {file = "coverage-5.3-cp39-cp39-win32.whl", hash = "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7"},
     {file = "coverage-5.3-cp39-cp39-win_amd64.whl", hash = "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7"},
     {file = "coverage-5.3.tar.gz", hash = "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0"},
+]
+dataclasses = [
+    {file = "dataclasses-0.7-py3-none-any.whl", hash = "sha256:3459118f7ede7c8bea0fe795bff7c6c2ce287d01dd226202f7c9ebc0610a7836"},
+    {file = "dataclasses-0.7.tar.gz", hash = "sha256:494a6dcae3b8bcf80848eea2ef64c0cc5cd307ffc263e17cdf42f3e5420808e6"},
 ]
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
@@ -656,17 +717,21 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 networkx = [
-    {file = "networkx-2.4-py3-none-any.whl", hash = "sha256:cdfbf698749a5014bf2ed9db4a07a5295df1d3a53bf80bf3cbd61edf9df05fa1"},
-    {file = "networkx-2.4.tar.gz", hash = "sha256:f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64"},
+    {file = "networkx-2.5-py3-none-any.whl", hash = "sha256:8c5812e9f798d37c50570d15c4a69d5710a18d77bafc903ee9c5fba7454c616c"},
+    {file = "networkx-2.5.tar.gz", hash = "sha256:7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
     {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
 ]
-pathlib2 = [
-    {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
-    {file = "pathlib2-2.3.5.tar.gz", hash = "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"},
+pathspec = [
+    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
+    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -703,6 +768,51 @@ pytest = [
 pytz = [
     {file = "pytz-2020.4-py2.py3-none-any.whl", hash = "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"},
     {file = "pytz-2020.4.tar.gz", hash = "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268"},
+]
+regex = [
+    {file = "regex-2020.10.28-cp27-cp27m-win32.whl", hash = "sha256:4b5a9bcb56cc146c3932c648603b24514447eafa6ce9295234767bf92f69b504"},
+    {file = "regex-2020.10.28-cp27-cp27m-win_amd64.whl", hash = "sha256:c13d311a4c4a8d671f5860317eb5f09591fbe8259676b86a85769423b544451e"},
+    {file = "regex-2020.10.28-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c454ad88e56e80e44f824ef8366bb7e4c3def12999151fd5c0ea76a18fe9aa3e"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c8a2b7ccff330ae4c460aff36626f911f918555660cc28163417cb84ffb25789"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4afa350f162551cf402bfa3cd8302165c8e03e689c897d185f16a167328cc6dd"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:b88fa3b8a3469f22b4f13d045d9bd3eda797aa4e406fde0a2644bc92bbdd4bdd"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f43109822df2d3faac7aad79613f5f02e4eab0fc8ad7932d2e70e2a83bd49c26"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:de7fd57765398d141949946c84f3590a68cf5887dac3fc52388df0639b01eda4"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:9b6305295b6591e45f069d3553c54d50cc47629eb5c218aac99e0f7fafbf90a1"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:bd904c0dec29bbd0769887a816657491721d5f545c29e30fd9d7a1a275dc80ab"},
+    {file = "regex-2020.10.28-cp36-cp36m-win32.whl", hash = "sha256:8092a5a06ad9a7a247f2a76ace121183dc4e1a84c259cf9c2ce3bbb69fac3582"},
+    {file = "regex-2020.10.28-cp36-cp36m-win_amd64.whl", hash = "sha256:49461446b783945597c4076aea3f49aee4b4ce922bd241e4fcf62a3e7c61794c"},
+    {file = "regex-2020.10.28-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:297116e79074ec2a2f885d22db00ce6e88b15f75162c5e8b38f66ea734e73c64"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8ca9dca965bd86ea3631b975d63b0693566d3cc347e55786d5514988b6f5b84c"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ea37320877d56a7f0a1e6a625d892cf963aa7f570013499f5b8d5ab8402b5625"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:3a5f08039eee9ea195a89e180c5762bfb55258bfb9abb61a20d3abee3b37fd12"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:cb905f3d2e290a8b8f1579d3984f2cfa7c3a29cc7cba608540ceeed18513f520"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:96f99219dddb33e235a37283306834700b63170d7bb2a1ee17e41c6d589c8eb9"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:227a8d2e5282c2b8346e7f68aa759e0331a0b4a890b55a5cfbb28bd0261b84c0"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:2564def9ce0710d510b1fc7e5178ce2d20f75571f788b5197b3c8134c366f50c"},
+    {file = "regex-2020.10.28-cp37-cp37m-win32.whl", hash = "sha256:a62162be05edf64f819925ea88d09d18b09bebf20971b363ce0c24e8b4aa14c0"},
+    {file = "regex-2020.10.28-cp37-cp37m-win_amd64.whl", hash = "sha256:03855ee22980c3e4863dc84c42d6d2901133362db5daf4c36b710dd895d78f0a"},
+    {file = "regex-2020.10.28-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bf4f896c42c63d1f22039ad57de2644c72587756c0cfb3cc3b7530cfe228277f"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux1_i686.whl", hash = "sha256:625116aca6c4b57c56ea3d70369cacc4d62fead4930f8329d242e4fe7a58ce4b"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dc522e25e57e88b4980d2bdd334825dbf6fa55f28a922fc3bfa60cc09e5ef53"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:119e0355dbdd4cf593b17f2fc5dbd4aec2b8899d0057e4957ba92f941f704bf5"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:cfcf28ed4ce9ced47b9b9670a4f0d3d3c0e4d4779ad4dadb1ad468b097f808aa"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:b45bab9f224de276b7bc916f6306b86283f6aa8afe7ed4133423efb42015a898"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:52e83a5f28acd621ba8e71c2b816f6541af7144b69cc5859d17da76c436a5427"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:aacc8623ffe7999a97935eeabbd24b1ae701d08ea8f874a6ff050e93c3e658cf"},
+    {file = "regex-2020.10.28-cp38-cp38-win32.whl", hash = "sha256:06b52815d4ad38d6524666e0d50fe9173533c9cc145a5779b89733284e6f688f"},
+    {file = "regex-2020.10.28-cp38-cp38-win_amd64.whl", hash = "sha256:c3466a84fce42c2016113101018a9981804097bacbab029c2d5b4fcb224b89de"},
+    {file = "regex-2020.10.28-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:127a9e0c0d91af572fbb9e56d00a504dbd4c65e574ddda3d45b55722462210de"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c2c6c56ee97485a127555c9595c069201b5161de9d05495fbe2132b5ac104786"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1ec66700a10e3c75f1f92cbde36cca0d3aaee4c73dfa26699495a3a30b09093c"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:11116d424734fe356d8777f89d625f0df783251ada95d6261b4c36ad27a394bb"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f1fce1e4929157b2afeb4bb7069204d4370bab9f4fc03ca1fbec8bd601f8c87d"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:3dfca201fa6b326239e1bccb00b915e058707028809b8ecc0cf6819ad233a740"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:b8a686a6c98872007aa41fdbb2e86dc03b287d951ff4a7f1da77fb7f14113e4d"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c32c91a0f1ac779cbd73e62430de3d3502bbc45ffe5bb6c376015acfa848144b"},
+    {file = "regex-2020.10.28-cp39-cp39-win32.whl", hash = "sha256:832339223b9ce56b7b15168e691ae654d345ac1635eeb367ade9ecfe0e66bee0"},
+    {file = "regex-2020.10.28-cp39-cp39-win_amd64.whl", hash = "sha256:654c1635f2313d0843028487db2191530bca45af61ca85d0b16555c399625b0e"},
+    {file = "regex-2020.10.28.tar.gz", hash = "sha256:dd3e6547ecf842a29cf25123fbf8d2461c53c8d37aa20d87ecee130c89b7079b"},
 ]
 requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
@@ -748,11 +858,48 @@ toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
+typed-ast = [
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
+    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
+    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
+    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
+    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+]
 urllib3 = [
     {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},
     {file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"},
 ]
 zipp = [
-    {file = "zipp-1.2.0-py2.py3-none-any.whl", hash = "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"},
-    {file = "zipp-1.2.0.tar.gz", hash = "sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1"},
+    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
+    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ depx = "depx.cli:main"
 "Bug Tracker" = "https://github.com/tilboerner/depx/issues"
 
 [tool.poetry.dependencies]
-python = "^3.5"
-Click = "~7.0"
+python = "^3.6"
+Click = "^7.1.2"
 jinja2 = "^2.11"
 networkx = "^2.3"
 pydot = "^1.4"
@@ -35,7 +35,31 @@ pytest = "^6.1"
 flake8 = "^3.8.4"
 coverage = "^5.3"
 Sphinx = "^3.3"
+black = "^20.8b1"
 
 [build-system]
 requires = ["poetry>=1.0"]
 build-backend = "poetry.masonry.api"
+
+[tool.black]
+line-length = 88
+skip-string-normalization = true
+target-version = ['py36']
+include = '\.pyi?$'
+exclude = '''
+
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+)
+'''

--- a/tests/test_depx.py
+++ b/tests/test_depx.py
@@ -10,6 +10,7 @@ fake_module = 'tests/fake_project/fake_module'
 
 def test_package_version_matches_project():
     import pkg_resources
+
     assert depx.__version__ == pkg_resources.get_distribution('depx').version
 
 
@@ -20,9 +21,7 @@ def test_command_line_interface():
     assert run_result.exit_code == 0
 
 
-@pytest.mark.parametrize('format', [
-    'json', 'html', 'graphml', 'dot'
-])
+@pytest.mark.parametrize('format', ['json', 'html', 'graphml', 'dot'])
 def test_export_to(format):
     runner = CliRunner()
     run_result = runner.invoke(cli.main, [fake_module, '--format', format])

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,6 @@
 import json
 
-from depx.graph import (
-    create_graph_from, to_html, to_graphml, to_dotfile, to_json
-)
+from depx.graph import create_graph_from, to_html, to_graphml, to_dotfile, to_json
 import networkx as nx
 import io
 import os
@@ -15,23 +13,23 @@ def dependencies():
         {
             "from_module": "opportunity.models",
             "to_module": "common.utils",
-            "category": "local"
+            "category": "local",
         },
         {
             "from_module": "opportunity.models",
             "to_module": "common.utils",
-            "category": "local"
+            "category": "local",
         },
         {
             "from_module": "sales_appoinment.views",
             "to_module": "common.utils",
-            "category": "local"
+            "category": "local",
         },
         {
             "from_module": "common.utils",
             "to_module": "opportunity.views",
-            "category": "local"
-        }
+            "category": "local",
+        },
     ]
 
 
@@ -47,7 +45,7 @@ def test_create_graph(dependencies):
     expected_edges = [
         ('opportunity.models', 'common.utils', {'weight': 2}),
         ('common.utils', 'opportunity.views', {'weight': 1}),
-        ('sales_appoinment.views', 'common.utils', {'weight': 1})
+        ('sales_appoinment.views', 'common.utils', {'weight': 1}),
     ]
     for node in graph.nodes():
         assert node in expected_nodes
@@ -87,7 +85,9 @@ def test_format_to_dotfile(dependencies):
     exported_graph = nx.drawing.nx_pydot.read_dot(io.StringIO(content))
 
     assert exported_graph.nodes() == graph.nodes()
-    assert nx.to_dict_of_dicts(graph).keys() == nx.to_dict_of_dicts(exported_graph).keys()
+    assert (
+        nx.to_dict_of_dicts(graph).keys() == nx.to_dict_of_dicts(exported_graph).keys()
+    )
 
 
 def test_format_to_json(dependencies):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,8 +1,13 @@
 from operator import itemgetter
 
 from depx.parsing import (
-    find_imports_from_text, _dependency, find_imports, _is_package,
-    _is_module, _find_base_name, filter_top_level_names
+    find_imports_from_text,
+    _dependency,
+    find_imports,
+    _is_package,
+    _is_module,
+    _find_base_name,
+    filter_top_level_names,
 )
 import os
 import pytest
@@ -10,145 +15,148 @@ import sys
 from textwrap import dedent
 
 
-@pytest.mark.parametrize('base_name,text,expected', [
-    (
-        'SINGLE_IMPORT',
-        'import some_module',
-        [
-            _dependency(
-                from_module='SINGLE_IMPORT',
-                from_name='some_module',
-                to_module='some_module',
-                to_name='some_module',
-                category='module',
-            ),
-        ],
-    ),
-    (
-        'ALIAS_IMPORT',
-        'import some_module as alias_name',
-        [
-            _dependency(
-                from_module='ALIAS_IMPORT',
-                from_name='alias_name',
-                to_module='some_module',
-                to_name='some_module',
-                category='module',
-            ),
-        ],
-    ),
-    (
-        'MULTI_IMPORT_ONE_LINE',
-        'import some_module, other_module as other_alias',
-        [
-            _dependency(
-                from_module='MULTI_IMPORT_ONE_LINE',
-                from_name='some_module',
-                to_module='some_module',
-                to_name='some_module',
-                category='module',
-            ),
-            _dependency(
-                from_module='MULTI_IMPORT_ONE_LINE',
-                from_name='other_alias',
-                to_module='other_module',
-                to_name='other_module',
-                category='module',
-            ),
-        ],
-    ),
-    (
-        'FROM_NAMESPACE_IMPORT_NAME',
-        'from some_namespace import some_name',
-        [
-            _dependency(
-                from_module='FROM_NAMESPACE_IMPORT_NAME',
-                from_name='some_name',
-                to_module='some_namespace',
-                to_name='some_name',
-                category='module',
-                is_relative=False,
-                level=0,
-            ),
-        ],
-    ),
-    (
-        'FROM_NAMESPACE_IMPORT_NAME_ALIAS',
-        'from some_namespace import some_name as alias_name',
-        [
-            _dependency(
-                from_module='FROM_NAMESPACE_IMPORT_NAME_ALIAS',
-                from_name='alias_name',
-                to_module='some_namespace',
-                to_name='some_name',
-                category='module',
-                is_relative=False,
-                level=0,
-            ),
-        ],
-    ),
-    (
-        'BASE_PACKAGE.RELATIVE_IMPORT',
-        'from . import some_module',
-        [
-            _dependency(
-                from_module='BASE_PACKAGE.RELATIVE_IMPORT',
-                from_name='some_module',
-                to_module='BASE_PACKAGE.some_module',
-                to_name='some_module',
-                category='module',
-                is_relative=True,
-                level=1,
-            ),
-        ],
-    ),
-    (
-        'BASE_PACKAGE.RELATIVE_IMPORT_TO_SIBLING',
-        'from .sibling_namespace import some_name',
-        [
-            _dependency(
-                from_module='BASE_PACKAGE.RELATIVE_IMPORT_TO_SIBLING',
-                from_name='some_name',
-                to_module='BASE_PACKAGE.sibling_namespace',
-                to_name='some_name',
-                category='module',
-                is_relative=True,
-                level=1,
-            ),
-        ],
-    ),
-    (
-        'RELATIVE_IMPORT_FROM_ROOT',
-        'from . import some_module',
-        [
-            _dependency(
-                from_module='RELATIVE_IMPORT_FROM_ROOT',
-                from_name='some_module',
-                to_module='some_module',
-                to_name='some_module',
-                category='module',
-                is_relative=True,
-                level=1,
-            ),
-        ],
-    ),
-    (
-        'LOCAL_IMPORT',
-        """
+@pytest.mark.parametrize(
+    'base_name,text,expected',
+    [
+        (
+            'SINGLE_IMPORT',
+            'import some_module',
+            [
+                _dependency(
+                    from_module='SINGLE_IMPORT',
+                    from_name='some_module',
+                    to_module='some_module',
+                    to_name='some_module',
+                    category='module',
+                ),
+            ],
+        ),
+        (
+            'ALIAS_IMPORT',
+            'import some_module as alias_name',
+            [
+                _dependency(
+                    from_module='ALIAS_IMPORT',
+                    from_name='alias_name',
+                    to_module='some_module',
+                    to_name='some_module',
+                    category='module',
+                ),
+            ],
+        ),
+        (
+            'MULTI_IMPORT_ONE_LINE',
+            'import some_module, other_module as other_alias',
+            [
+                _dependency(
+                    from_module='MULTI_IMPORT_ONE_LINE',
+                    from_name='some_module',
+                    to_module='some_module',
+                    to_name='some_module',
+                    category='module',
+                ),
+                _dependency(
+                    from_module='MULTI_IMPORT_ONE_LINE',
+                    from_name='other_alias',
+                    to_module='other_module',
+                    to_name='other_module',
+                    category='module',
+                ),
+            ],
+        ),
+        (
+            'FROM_NAMESPACE_IMPORT_NAME',
+            'from some_namespace import some_name',
+            [
+                _dependency(
+                    from_module='FROM_NAMESPACE_IMPORT_NAME',
+                    from_name='some_name',
+                    to_module='some_namespace',
+                    to_name='some_name',
+                    category='module',
+                    is_relative=False,
+                    level=0,
+                ),
+            ],
+        ),
+        (
+            'FROM_NAMESPACE_IMPORT_NAME_ALIAS',
+            'from some_namespace import some_name as alias_name',
+            [
+                _dependency(
+                    from_module='FROM_NAMESPACE_IMPORT_NAME_ALIAS',
+                    from_name='alias_name',
+                    to_module='some_namespace',
+                    to_name='some_name',
+                    category='module',
+                    is_relative=False,
+                    level=0,
+                ),
+            ],
+        ),
+        (
+            'BASE_PACKAGE.RELATIVE_IMPORT',
+            'from . import some_module',
+            [
+                _dependency(
+                    from_module='BASE_PACKAGE.RELATIVE_IMPORT',
+                    from_name='some_module',
+                    to_module='BASE_PACKAGE.some_module',
+                    to_name='some_module',
+                    category='module',
+                    is_relative=True,
+                    level=1,
+                ),
+            ],
+        ),
+        (
+            'BASE_PACKAGE.RELATIVE_IMPORT_TO_SIBLING',
+            'from .sibling_namespace import some_name',
+            [
+                _dependency(
+                    from_module='BASE_PACKAGE.RELATIVE_IMPORT_TO_SIBLING',
+                    from_name='some_name',
+                    to_module='BASE_PACKAGE.sibling_namespace',
+                    to_name='some_name',
+                    category='module',
+                    is_relative=True,
+                    level=1,
+                ),
+            ],
+        ),
+        (
+            'RELATIVE_IMPORT_FROM_ROOT',
+            'from . import some_module',
+            [
+                _dependency(
+                    from_module='RELATIVE_IMPORT_FROM_ROOT',
+                    from_name='some_module',
+                    to_module='some_module',
+                    to_name='some_module',
+                    category='module',
+                    is_relative=True,
+                    level=1,
+                ),
+            ],
+        ),
+        (
+            'LOCAL_IMPORT',
+            """
         def function():
             import some_module
         """,
-        [
-            _dependency(
-                from_module='LOCAL_IMPORT',
-                from_name='some_module',
-                to_module='some_module',
-                to_name='some_module',
-                category='local',
-            ),
-        ],
-    ),
-])
+            [
+                _dependency(
+                    from_module='LOCAL_IMPORT',
+                    from_name='some_module',
+                    to_module='some_module',
+                    to_name='some_module',
+                    category='local',
+                ),
+            ],
+        ),
+    ],
+)
 def test_find_imports_from_text(base_name, text, expected):
     text = dedent(text)
     assert list(find_imports_from_text(text, base_name)) == expected
@@ -156,13 +164,17 @@ def test_find_imports_from_text(base_name, text, expected):
 
 @pytest.mark.skipif(sys.version_info < (3, 5), reason='async not in older Pythons')
 def test_find_imports_from_text__async_def():
-    imports = list(find_imports_from_text(
-        dedent("""
+    imports = list(
+        find_imports_from_text(
+            dedent(
+                """
         async def function():
             import some_module
-        """),
-        base_name='TEST_MODULE',
-    ))
+        """
+            ),
+            base_name='TEST_MODULE',
+        )
+    )
 
     assert imports == [
         _dependency(
@@ -175,11 +187,14 @@ def test_find_imports_from_text__async_def():
     ]
 
 
-@pytest.mark.parametrize('path,expected', [
-    (os.getcwd() + '/tests/fake_project/another_fake_module', True),
-    (os.getcwd() + '/tests/fake_project/fake_module', True),
-    (os.getcwd() + '/tests/fake_project/random_folder', False),
-])
+@pytest.mark.parametrize(
+    'path,expected',
+    [
+        (os.getcwd() + '/tests/fake_project/another_fake_module', True),
+        (os.getcwd() + '/tests/fake_project/fake_module', True),
+        (os.getcwd() + '/tests/fake_project/random_folder', False),
+    ],
+)
 def test_is_package(path, expected):
     assert _is_package(path) is expected
 
@@ -193,7 +208,7 @@ def test_find_imports():
             'is_relative': False,
             'from_name': 'oh_nice',
             'to_name': 'oh_nice',
-            'level': 0
+            'level': 0,
         },
         {
             'from_module': 'another_fake_module.missing_creativity',
@@ -202,7 +217,7 @@ def test_find_imports():
             'is_relative': False,
             'from_name': 'random',
             'to_name': 'random',
-            'level': 0
+            'level': 0,
         },
         {
             'from_module': 'fake_module.__init__',
@@ -211,7 +226,7 @@ def test_find_imports():
             'is_relative': False,
             'from_name': 'fake_module.a_module',
             'to_name': 'fake_module.a_module',
-            'level': 0
+            'level': 0,
         },
         {
             'from_module': 'fake_module.__init__',
@@ -220,9 +235,8 @@ def test_find_imports():
             'is_relative': False,
             'from_name': 'another_module',
             'to_name': 'another_module',
-            'level': 0
+            'level': 0,
         },
-
         {
             'from_module': 'fake_module.a_module',
             'to_module': 'fake_module.another_module',
@@ -230,32 +244,49 @@ def test_find_imports():
             'is_relative': True,
             'from_name': 'oh_nice',
             'to_name': 'oh_nice',
-            'level': 1
-        }
+            'level': 1,
+        },
     ]
     by_name = itemgetter('from_module', 'from_name', 'to_module', 'to_name')
-    assert sorted(find_imports('tests/fake_project'), key=by_name) == sorted(expected, key=by_name)
+    assert sorted(find_imports('tests/fake_project'), key=by_name) == sorted(
+        expected, key=by_name
+    )
 
 
-@pytest.mark.parametrize('path,expected', [
-    (os.getcwd() + '/tests/fake_project/another_fake_module/__init__.py', True),
-    (os.getcwd() + '/tests/fake_project/another_fake_module/missing_creativity.py', True),
-    (os.getcwd() + '/tests/fake_project/setup.py', True),
-    (os.getcwd() + '/tests/fake_project/random_folder/python_file_without_py_extension.txt', True),
-    (os.getcwd() + '/tests/fake_project/random_folder/cool_file.txt', False),
-])
+@pytest.mark.parametrize(
+    'path,expected',
+    [
+        (os.getcwd() + '/tests/fake_project/another_fake_module/__init__.py', True),
+        (
+            os.getcwd()
+            + '/tests/fake_project/another_fake_module/missing_creativity.py',
+            True,
+        ),
+        (os.getcwd() + '/tests/fake_project/setup.py', True),
+        (
+            os.getcwd()
+            + '/tests/fake_project/random_folder/python_file_without_py_extension.txt',
+            True,
+        ),
+        (os.getcwd() + '/tests/fake_project/random_folder/cool_file.txt', False),
+    ],
+)
 def test_is_module(path, expected):
     assert _is_module(path) is expected
 
 
-@pytest.mark.parametrize('path,expected', [
-    ('tests/fake_project/another_fake_module/__init__.py', 'another_fake_module'),
-    (
-        os.getcwd() + '/tests/fake_project/another_fake_module/missing_creativity.py',
-        'another_fake_module'
-    ),
-    ('tests/fake_project/setup.py', ''),
-])
+@pytest.mark.parametrize(
+    'path,expected',
+    [
+        ('tests/fake_project/another_fake_module/__init__.py', 'another_fake_module'),
+        (
+            os.getcwd()
+            + '/tests/fake_project/another_fake_module/missing_creativity.py',
+            'another_fake_module',
+        ),
+        ('tests/fake_project/setup.py', ''),
+    ],
+)
 def test_find_base_name(path, expected):
     assert _find_base_name(path) == expected
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py35, py36, py37, flake8
+envlist = py36, py37, flake8
 isolated_build = true
 
 [travis]
 python =
     3.7: py37
     3.6: py36
-    3.5: py35
 
 [testenv:flake8]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py36, py37, flake8
+envlist = py36, py37, py38, py39, flake8
 isolated_build = true
 
 [travis]
 python =
+    3.9: py39
+    3.8: py38
     3.7: py37
     3.6: py36
 


### PR DESCRIPTION
Fix #16 : Add black auto formatter to project and adopt configuration.

* Drops support for Python 3.5
* Extends tox tests for Python 3.8 & 3.9